### PR TITLE
ADD perms to 'cinema club' role under 'create_event' and Indonesian flag in dynamic rooms

### DIFF
--- a/cogs/eventmanagement.py
+++ b/cogs/eventmanagement.py
@@ -100,6 +100,14 @@ class EventManagement(commands.Cog):
 
         overwrites = await self.get_event_permissions(guild)
 
+        cinema_club_role = discord.utils.get(
+            guild.roles, id=int(os.getenv('CINEMA_CLUB_ROLE_ID'))
+        )
+        # Adds some perms to the Cinema Club role
+        overwrites[cinema_club_role] = discord.PermissionOverwrite(
+            read_messages=True, send_messages=True,
+            connect=True, speak=True, view_channel=True)
+
         events_category = discord.utils.get(
             guild.categories, id=int(os.getenv('EVENTS_CAT_ID')))
 

--- a/sql/create_dynamic_room_setup.sql
+++ b/sql/create_dynamic_room_setup.sql
@@ -110,7 +110,7 @@ INSERT INTO Sloth.LanguageRoom (category, english_name, room_name, room_quant, r
 /* 085 */("south-east asian", "Cebuano", "Cebuano 🥥🇵🇭", 2, 10, 60),
 /* 086 */("south-east asian", "Ilocano", "Ilocano", 2, 10, 60),
 
-/* 087 */("south-east asian", "Javanese", "Bahasa Jawa 🦜", 2, 10, 60),
+/* 087 */("south-east asian", "Javanese", "Bahasa Jawa 🇮🇩🦜", 2, 10, 60),
 /* 088 */("south-east asian", "Lao", "ພາສາລາວ", 2, 10, 60),
 
 /* 089 */("romance", "Portunhol", "Portuñol 🧉🌎", 2, 10, 60),
@@ -153,7 +153,7 @@ INSERT INTO Sloth.LanguageRoom (category, english_name, room_name, room_quant, r
 
 /* 118 */("uralic", "Estonian", "Estonian", 2, 10, 60 * 60 * 1),
 
-/* 119 */("south-east asian", "Bahasa Batak", "Bahasa Batak 🦏", 2, 10, 60),
+/* 119 */("south-east asian", "Bahasa Batak", "Bahasa Batak 🇮🇩🦏", 2, 10, 60),
 
 /* 120 */("celtic", "Celtic", "Celtic", 2, 10, 60),
 


### PR DESCRIPTION
Unlike the other events, Cinema events have no permissions related to the role "Cinema club"; Added indonesian flag along with the name of two indonesian Dynamic rooms.