### PR TITLE
Fixed so the temp unmute works again

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -196,13 +196,15 @@ class Moderation(*moderation_cogs):
 						if role in member_roles:
 							member_roles.remove(role)
 
-						await member.edit(roles=member_roles)
 						try:
 							await self.remove_all_roles_from_system(member.id)
 						except Exception as e:
 							print(e)
 							pass
 						else:
+							# Update member roles
+							await member.edit(roles=member_roles)
+							
 							current_time = await utils.get_time_now()
 
 							# Moderation log embed


### PR DESCRIPTION
After fixing it so muted users cannot pick roles, the user has to be removed from the database first before they can have their roles back. This is because the event cancels every role update if the user is in the muted database.