### PR TITLE
fix: possibly fixes the nitro kick confirmation problem

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1492,7 +1492,7 @@ We appreciate your understanding and look forward to hearing from you. """, embe
 					if await utils.is_allowed([senior_mod_role_id]).predicate(channel=ctx.channel, member=u):
 						should_nitro_kick = True
 						break
-					elif len(confirmations) > 0:
+					elif len(confirmations) >= 0:
 						if len(confirmations) < 3:
 							continue
 						elif len(confirmations) >= 3:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1492,8 +1492,12 @@ We appreciate your understanding and look forward to hearing from you. """, embe
 					if await utils.is_allowed([senior_mod_role_id]).predicate(channel=ctx.channel, member=u):
 						should_nitro_kick = True
 						break
-					elif len(confirmations) < 3:
-						continue
+					elif len(confirmations) > 0:
+						if len(confirmations) < 3:
+							continue
+						elif len(confirmations) >= 3:
+							should_nitro_kick = True
+							break
 					else:
 						break
 


### PR DESCRIPTION
Currently, nitro kick doesn't work with moderators when 3 or more mods click on the nitro kick confirmation.
Looks like a basic fix.