### PR TITLE
Improved modrep and fixed mods not showing on command when the data is reset.

### DIFF
--- a/cogs/modactivity.py
+++ b/cogs/modactivity.py
@@ -137,7 +137,6 @@ class ModActivity(ModActivityTable):
         if moderator_role not in mod.roles:
             return await ctx.send(f"**{mod.mention} is not a moderator!**")
 
-        print("TESTE CARALHO")
         if await self.check_mod_activity_exists(mod.id):
             return await ctx.send(f"**Moderator {mod.mention} is already being tracked!**")
 

--- a/cogs/modactivity.py
+++ b/cogs/modactivity.py
@@ -107,6 +107,7 @@ class ModActivity(ModActivityTable):
 
         async def add_mods_to_embed(mods):
             nonlocal field_count
+            nonlocal embed
             for mod in mods:
                 embed.add_field(
                 name=f"{mod['icon']}**{mod['user']}**",
@@ -149,6 +150,7 @@ class ModActivity(ModActivityTable):
     @utils.is_allowed([senior_mod_role_id], throw_exc=True)
     @commands.command(aliases=['track_mod'])
     async def track_mod_activity(self, ctx, mod: discord.Member):
+        """ (STAFF) Starts tracking a moderator activity. """
         guild = self.client.get_guild(guild_id)
         moderator_role = discord.utils.get(guild.roles, id=mod_role_id)
 
@@ -160,6 +162,23 @@ class ModActivity(ModActivityTable):
 
         await self.insert_moderator(mod.id)
         return await ctx.send(f"**Tracking {mod.mention} activity!**")
+
+    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @commands.command(aliases=['untrack_mod'])
+    async def untrack_mod_activity(self, ctx, mod: discord.Member):
+        """ (STAFF) Stop tracking a moderator activity. Use this command if an user is no longer a moderator. """
+
+        guild = self.client.get_guild(guild_id)
+        moderator_role = discord.utils.get(guild.roles, id=mod_role_id)
+
+        if moderator_role not in mod.roles:
+            return await ctx.send(f"**{mod.mention} is not a moderator!**")
+
+        if not await self.check_mod_activity_exists(mod.id):
+            return await ctx.send(f"**Moderator {mod.mention} is not being tracked!**")
+
+        await self.remove_moderator(mod.id)
+        return await ctx.send(f"**Untracking {mod.mention} activity!**")
 
 
 def setup(client):

--- a/cogs/modactivity.py
+++ b/cogs/modactivity.py
@@ -121,13 +121,28 @@ class ModActivity(ModActivityTable):
         if confirm_view.value is None:
             await ctx.send(f"**Timeout, not deleting it, {member.mention}!**", delete_after=3)
         elif confirm_view.value:
-            await self.delete_mod_activity()
+            await self.reset_mod_activity()
             await ctx.send(f"**Mod Activity data reset, {member.mention}!**", delete_after=3)
         else:
             await ctx.send(f"**Not deleting it then, {member.mention}!**", delete_after=3)
 
         await msg.delete()
 
+    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @commands.command(aliases=['track_mod'])
+    async def track_mod_activity(self, ctx, mod: discord.Member):
+        guild = self.client.get_guild(guild_id)
+        moderator_role = discord.utils.get(guild.roles, id=mod_role_id)
+
+        if moderator_role not in mod.roles:
+            return await ctx.send(f"**{mod.mention} is not a moderator!**")
+
+        print("TESTE CARALHO")
+        if await self.check_mod_activity_exists(mod.id):
+            return await ctx.send(f"**Moderator {mod.mention} is already being tracked!**")
+
+        await self.insert_moderator(mod.id)
+        return await ctx.send(f"**Tracking {mod.mention} activity!**")
 
 
 def setup(client):

--- a/extra/moderation/modactivity.py
+++ b/extra/moderation/modactivity.py
@@ -84,6 +84,14 @@ class ModActivityTable(commands.Cog):
         await self.db.execute_query("""
             INSERT INTO ModActivity (mod_id, timestamp, messages) VALUES (%s, %s, %s)
             """, (mod_id, old_ts, messages))
+    async def remove_moderator(self, mod_id: int) -> None:
+        """ Removes a moderator from ModActivity table.
+        :param mod_id: The ID of the moderator to remove.
+        """
+
+        await self.db.execute_query("""
+            DELETE FROM ModActivity WHERE mod_id = %s
+            """, (mod_id,))
 
     async def get_mod_activities(self) -> List[List[int]]:
         """ Gets all Mod activities data from the database. """

--- a/extra/moderation/modactivity.py
+++ b/extra/moderation/modactivity.py
@@ -68,6 +68,13 @@ class ModActivityTable(commands.Cog):
 
         return await self.db.table_exists("ModActivity")
 
+    async def check_mod_activity_exists(self, mod_id: int) -> bool:
+        """ Checks if a moderator already exists in the ModActivity table. """
+
+        mod = await self.db.execute_query("SELECT 1 FROM ModActivity WHERE mod_id = %s", (mod_id,), fetch="one")
+
+        return bool(mod)
+
     async def insert_moderator(self, mod_id: int, old_ts: Optional[int] = None, messages: Optional[int] = 0) -> None:
         """ Inserts a moderator.
         :param mod_id: The ID of the moderator to insert.
@@ -81,7 +88,7 @@ class ModActivityTable(commands.Cog):
     async def get_mod_activities(self) -> List[List[int]]:
         """ Gets all Mod activities data from the database. """
 
-        return await self.db.execute_query("SELECT * FROM ModActivity ORDER BY time DESC", fetch="all")
+        return await self.db.execute_query("SELECT * FROM ModActivity ORDER BY time DESC, messages DESC", fetch="all")
 
     async def get_moderator_current_timestamp(self, mod_id: int, old_ts: Optional[int] = None) -> int:
         """ Gets the moderator's current timestamp.
@@ -127,6 +134,11 @@ class ModActivityTable(commands.Cog):
         :param addition: The addition value. """
 
         await self.db.execute_query("UPDATE ModActivity SET time = time + %s WHERE mod_id = %s", (addition, mod_id))
+
+    async def reset_mod_activity(self) -> None:
+        """ Reset data from the ModActivity table """
+
+        await self.db.execute_query("UPDATE ModActivity SET time = 0, timestamp = 0, messages = 0")
 
     async def delete_mod_activity(self) -> None:
         """ Deletes all the data from the ModActivity table. """


### PR DESCRIPTION
Also added two staff commands:
track_mod_activity -> To add the missing moderators to the ModActivity table ( this command can be removed afterwards ).
untrack_mod_activity -> To stop tracking a moderator's activity if they are no longer part of the team.