### PR TITLE
feat: ban timeout embed now outputs the command

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -422,7 +422,7 @@ class Moderation(*moderation_cogs):
 
         special_channels = {
             int(os.getenv('MUTED_CHANNEL_ID', 123)): 'https://cdn.discordapp.com/attachments/746478846466981938/748605295122448534/Muted.png',
-            int(os.getenv('QUESTION_CHANNEL_ID', 123)): '''**Have a question about the server? Ask it here!**'''
+            int(os.getenv('QUESTION_CHANNEL_ID', 123)): '''**Have a question about the server? Ask it here!**\nThe chat will be cleared once questions are answered.'''
         }
 
         if ctx.channel.id not in special_channels.keys():

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1313,6 +1313,11 @@ class Moderation(*moderation_cogs):
                         r, u = await self.client.wait_for('reaction_add', timeout=300, check=check_staff_manager)
                     except asyncio.TimeoutError:
                         mod_ban_embed.description = f'Timeout, {member} is not getting banned!'
+                        mod_ban_embed.add_field(
+                            name="Command",
+                            value=f"```z!ban {member.id} {reason}```",
+                            inline=False
+                        )
                         await msg.remove_reaction('✅', self.client.user)
                         await msg.edit(embed=mod_ban_embed)
                         break


### PR DESCRIPTION
- for the ease of use when staff members want to send the request again
- also changed the question channel clear message as requested

tested and works.