### PR TITLE
feat: "easier" version of the warn command

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -532,7 +532,10 @@ class Moderation(*moderation_cogs):
         :param member: The @ or the ID of one or more users to soft warn.
         :param reason: The reason for warning one or all users. (Optional)"""
 
-        await self._warn_callback(ctx=ctx, message=message, warn_type="lwarn")
+        if not message:
+            await self._easy_warn_callback(ctx=ctx, warn_type="lwarn")
+        else:
+            await self._warn_callback(ctx=ctx, message=message, warn_type="lwarn")
 
     @commands.command(aliases=["warnado", "wrn"])
     @utils.is_allowed(allowed_roles, throw_exc=True)
@@ -541,7 +544,10 @@ class Moderation(*moderation_cogs):
         :param member: The @ or the ID of one or more users to warn.
         :param reason: The reason for warning one or all users. (Optional)"""
 
-        await self._warn_callback(ctx=ctx, message=message, warn_type="warn")
+        if not message:
+            await self._easy_warn_callback(ctx=ctx, warn_type="warn")
+        else:
+            await self._warn_callback(ctx=ctx, message=message, warn_type="warn")
 
     @commands.command(aliases=["hwarn", "hwarnado", "hwrn"])
     @utils.is_allowed(allowed_roles, throw_exc=True)
@@ -550,7 +556,11 @@ class Moderation(*moderation_cogs):
         :param member: The @ or the ID of one or more users to warn.
         :param reason: The reason for warning one or all users. (Optional)"""
         
-        await self._warn_callback(ctx=ctx, message=message, warn_type="hwarn")
+        if not message:
+            await self._easy_warn_callback(ctx=ctx, warn_type="hwarn")
+        else:
+            await self._warn_callback(ctx=ctx, message=message, warn_type="hwarn")
+        
     async def _easy_warn_callback(self, ctx, warn_type: str = "warn") -> None:
         """ Callback for the easy warn.
         :param warn_type: The warn type. [light/normal/heavy]"""

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -12,7 +12,7 @@ from discord.ext import commands, menus, tasks
 
 # import.local
 from extra import utils
-from extra.menu import MemberSnipeLooping, SnipeLooping
+from extra.menu import MemberSnipeLooping, SnipeLooping, prompt_message_guild, prompt_number
 from extra.moderation.fakeaccounts import ModerationFakeAccountsTable
 from extra.moderation.firewall import (BypassFirewallTable,
                                        ModerationFirewallTable)
@@ -23,7 +23,7 @@ from extra.moderation.userinfractions import ModerationUserInfractionsTable
 from extra.moderation.watchlist import ModerationWatchlistTable
 from extra.prompt.menu import Confirm
 from extra.useful_variables import banned_links
-from extra.view import ReportSupportView
+from extra.view import ReportSupportView, WarnRulesView
 from mysqldb import DatabaseCore
 
 # variables.id
@@ -551,6 +551,53 @@ class Moderation(*moderation_cogs):
         :param reason: The reason for warning one or all users. (Optional)"""
         
         await self._warn_callback(ctx=ctx, message=message, warn_type="hwarn")
+    async def _easy_warn_callback(self, ctx, warn_type: str = "warn") -> None:
+        """ Callback for the easy warn.
+        :param warn_type: The warn type. [light/normal/heavy]"""
+        
+        author = ctx.author
+        channel = ctx.channel
+
+        await ctx.send(f"**{author.mention}, type the ID of the user that will to get warned.\n- (Multiple ID's work as well.)**")
+        if not (ids := await prompt_message_guild(client=self.client, member=author, channel=channel, limit=180)):
+            return
+
+        rule_embed: discord.Embed = discord.Embed(
+            title="__Warn Rule Selection__",
+            color=author.color,
+            timestamp=ctx.message.created_at
+        )
+        rule_embed.set_author(name=author, icon_url=author.display_avatar)
+        rule_embed.set_thumbnail(url=author.display_avatar)
+        rule_embed.set_footer(text="3 minutes to select.", icon_url=ctx.guild.icon.url)
+
+        view: discord.ui.View = WarnRulesView(author)
+        msg = await ctx.send(embed=rule_embed, view=view)
+        await view.wait()
+        await utils.disable_buttons(view)
+        await msg.edit(view=view)
+
+        if view.selected_rule is None:
+            await ctx.send(f"- **Rule selection cancelled, warn aborted.**")
+            return
+
+        if not view.selected_rule:
+            await ctx.send(f"- **No rules have been selected, warn aborted.**")
+            return
+
+        await ctx.send(f"**- Rule selection successful!**")
+
+        await ctx.send(f"- **{author.mention}, specify the reason you're warning this/these member(s).**")
+        if not (personal_message := await prompt_message_guild(client=self.client, member=author, channel=channel, limit=860)):
+            return
+            
+        reason_output = f"{view.selected_rule.label}: {view.selected_rule.description}"
+
+        output = f"{ids} {reason_output} {personal_message}"
+        
+        confirm = await Confirm(f"**Are you sure about about this/these `{warn_type}(s)`?**\n- ID(s): `{ids}` \n- Selected rule: `{reason_output}`\n- Reason: `{personal_message}`").prompt(ctx)
+        if confirm:
+            await self._warn_callback(ctx=ctx, message=output, warn_type=warn_type)
 
     async def _warn_callback(self, ctx, *, message: Optional[str] = None, warn_type: str = "warn") -> None:
         """ Callback for the warn commands.

--- a/extra/view.py
+++ b/extra/view.py
@@ -661,3 +661,66 @@ class BootcampFeedbackView(discord.ui.View):
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         return self.perpetrator.id == interaction.user.id
+
+class WarnRulesView(discord.ui.View):
+    """ View for the WarnRules selection. """
+
+    def __init__(self, member: discord.Member, timeout: Optional[float] = 180):
+        super().__init__(timeout=timeout)
+        self.member = member
+        self.selected_rule: str = None
+
+        options = [
+            discord.SelectOption(label="R1", description="NSFW is forbidden."),
+            discord.SelectOption(label="R2", description="Be respectful."),
+            discord.SelectOption(label="R3", description="Avoid controversy."),
+            discord.SelectOption(label="R4", description="Advertising is forbidden."),
+            discord.SelectOption(label="R5", description="Do not dox."),
+            discord.SelectOption(label="R6", description="Do not spam."),
+            discord.SelectOption(label="R7", description="Do not impersonate others."),
+            discord.SelectOption(label="R8", description="Do not beg."),
+            discord.SelectOption(label="R9", description="Do not cause drama."),
+        ]
+
+        rule_select = discord.ui.Select(
+            placeholder="Choose a rule for this warn...", custom_id="warn_rules_view_select_id", 
+            options=options)
+
+        rule_select.callback = partial(self.select_rule_select, rule_select)
+
+        self.children.insert(0, rule_select)
+
+    async def select_rule_select(self, select: discord.ui.select, interaction: discord.Interaction) -> None:
+        """ Callback for a select menu option. """
+
+        embed = interaction.message.embeds[0]
+        selected_label = interaction.data['values'][0]
+        selected_option = next((option for option in select.options if option.label == selected_label), None)
+        embed.clear_fields()
+        embed.add_field(name="Selected Rule:", value=f"{selected_label}: {selected_option.description}")
+        self.selected_rule = selected_option
+
+        await interaction.response.edit_message(embed=embed)
+
+    @discord.ui.button(label="Confirm", custom_id="confirm_rule_selection_id", style=discord.ButtonStyle.success, emoji="✅", row=1)
+    async def confirm_rule_selection_button(self, button: discord.ui.button, interaction: discord.Interaction) -> None:
+        """ Confirms the rule selection. """
+
+        if not self.selected_rule:
+            return await interaction.response.send_message("**You must choose an option to confirm!**", ephemeral=True)
+
+        await interaction.response.defer()
+        self.stop()
+
+    @discord.ui.button(label="Cancel", custom_id="cancel_rule_selection_id", style=discord.ButtonStyle.danger, emoji="❌", row=1)
+    async def cancel_rule_selection_button(self, button: discord.ui.button, interaction: discord.Interaction) -> None:
+        """ Cancels the rule selection. """
+
+        await interaction.response.defer()
+        self.selected_rule = None
+        self.stop()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """ Checks whether the click was done by the author of the command. """
+
+        return self.member.id == interaction.user.id


### PR DESCRIPTION
sort of a test about the easy warn command thingy we talked about a while ago

- now, the warn commands start up a sequence when executed without any arguments
- asks for id, makes you select a rule from a drop-down menu and asks for the reason of warning

tested and works.