### PR TITLE
refactor: lesson managers perm for infraction command and new limitations

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2176,7 +2176,7 @@ We appreciate your understanding and look forward to hearing from you. """, embe
 
         # multiple roles, not in the respective channel/thread
         if not is_allowed and (is_sub or is_lesson_manager or is_event_manager) and ctx.channel.id not in {frog_catchers_channel_id, teacher_applicant_infraction_thread_id, host_applicant_infraction_thread_id}:
-            return await ctx.send(f"**Users with multiple roles that has the limited infraction perms can only see infractions in their respective channels: <#{frog_catchers_channel_id}>, <#{teacher_applicant_infraction_thread_id}>, or <#{host_applicant_infraction_thread_id}>!")
+            return await ctx.send(f"**Users with multiple roles that has the limited infraction perms can only see infractions in their respective channels: <#{frog_catchers_channel_id}>, <#{teacher_applicant_infraction_thread_id}>, or <#{host_applicant_infraction_thread_id}>!**")
 
         try:
             await ctx.message.delete()

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2157,7 +2157,7 @@ We appreciate your understanding and look forward to hearing from you. """, embe
 
         allowed_room_and_user = ctx.channel.id not in watchlist_disallowed_channels and any(role.id in allowed_roles for role in ctx.author.roles)
 
-        is_allowed = await utils.is_allowed([*allowed_roles, event_manager_role_id]).predicate(ctx)
+        is_allowed = await utils.is_allowed(allowed_roles).predicate(ctx)
         is_sub = await utils.is_subscriber(throw_exc=False).predicate(ctx)
         is_lesson_manager = await utils.is_allowed([lesson_manager_role_id]).predicate(ctx)
         is_event_manager = await utils.is_allowed([event_manager_role_id]).predicate(ctx)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2150,7 +2150,7 @@ We appreciate your understanding and look forward to hearing from you. """, embe
 
     # Infraction methods
     @commands.command(aliases=['infr', 'show_warnings', 'sw', 'show_bans', 'sb', 'show_muted', 'sm'])
-    @commands.check_any(utils.is_allowed([*allowed_roles, event_manager_role_id, analyst_debugger_role_id], throw_exc=True), utils.is_subscriber())
+    @commands.check_any(utils.is_allowed([*allowed_roles, event_manager_role_id, lesson_manager_role_id, analyst_debugger_role_id], throw_exc=True), utils.is_subscriber())
     async def infractions(self, ctx, *, message : str = None) -> None:
         """ Shows all infractions of a specific user.
         :param member: The member to show the infractions from. [Optional] [Default = You] """


### PR DESCRIPTION
- now, lesson managers can also use the infraction command
- both lesson and event managers are now limited to use the command in their respective threads

tested and works.