### PR TITLE
Update reportsupport.py

### DIFF
--- a/cogs/reportsupport.py
+++ b/cogs/reportsupport.py
@@ -471,31 +471,31 @@ class ReportSupport(*report_support_classes):
         
         if (vc_name == "Staff"):
             senior_mod = discord.utils.get(guild.roles, id=senior_role_id)
-            overwrites |= {
+            overwrites.update({
                 moderator: discord.PermissionOverwrite(
                     read_messages=False, 
                     send_messages=False, 
                     connect=False, 
                     view_channel=False, 
-                    manage_messages=False,),
+                    manage_messages=False),
                 senior_mod: discord.PermissionOverwrite(
                     read_messages=True, 
                     send_messages=True, 
                     connect=False, 
                     view_channel=True, 
-                    manage_messages=True,)
-            }
+                    manage_messages=True)
+            })
         else:
-            overwrites |= {
+            overwrites.update({
                 moderator: discord.PermissionOverwrite(
                     read_messages=True, 
                     send_messages=True, 
                     connect=False, 
                     view_channel=True, 
                     manage_messages=True, 
-                    manage_permissions=True,)
-            }
-        
+                    manage_permissions=True)
+            })
+
         # Verifies if the user already has an open text channel
         if open_channel := await self.member_has_open_channel(member.id):
             if open_channel := discord.utils.get(guild.text_channels, id=open_channel[1]):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+anthropic==0.45.2
 wikipedia==1.4.0
 aiohttp==3.7.4
 aiomysql==0.0.22
@@ -11,7 +12,7 @@ pytest==7.0.1
 pytest-asyncio==0.18.1
 pytz==2021.1
 gTTS==2.2.3
-googletrans==3.1.0a0
+googletrans==4.0.2
 mysqlclient==2.2.4
 mysql-connector-python==9.0.0
 mypy==0.931


### PR DESCRIPTION
Fixed the error "unsupported operand type(s) for |=: 'dict' and 'dict'" as the |= operator for merging dictionaries was introduced in Python 3.9 and the bot is using Python 3.8