### PR TITLE
fix(mute): integration roles break mute command

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -850,7 +850,10 @@ class Moderation(*moderation_cogs):
                 if member_role.id == role.id:
                     keep_list.append(role)
                     continue
-
+            
+            if member_role.managed:
+                keep_list.append(member_role)
+            
             if member_role < bot.top_role:
                 if not member_role.is_premium_subscriber():
                     remove_list.append(member_role)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -851,12 +851,12 @@ class Moderation(*moderation_cogs):
                     keep_list.append(role)
                     continue
             
+            if member_role < bot.top_role:
+                if not member_role.is_premium_subscriber() or not member_role.managed:
+                    remove_list.append(member_role)
+
             if member_role.managed:
                 keep_list.append(member_role)
-            
-            if member_role < bot.top_role:
-                if not member_role.is_premium_subscriber():
-                    remove_list.append(member_role)
 
             if member_role.is_premium_subscriber():
                 keep_list.append(member_role)


### PR DESCRIPTION
users with this role was basically untouchable by the mute command, good thing that they didn't know this

- bot will not try to remove integration roles anymore

not tested, hopefully works.