### PR TITLE
feat/refactor: everything requested in bulk

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -867,7 +867,7 @@ class Moderation(*moderation_cogs):
         general_embed.set_author(name=f"{member} has been timed out", icon_url=member.display_avatar)
         await ctx.send(embed=general_embed)
         
-    @commands.command(aliases=["rto", "remove_to"])
+    @commands.command(aliases=["rto", "rtimeout", "remove_to"])
     @commands.has_permissions(administrator=True)
     async def remove_timeout(self, ctx, member: discord.Member = None):
         """(ADM) Removes the timeout from a member and removes the timeout role.

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2536,6 +2536,7 @@ We appreciate your understanding and look forward to hearing from you. """, embe
 
                 try:
                     if user_infraction[0][1] != "watchlist":
+                        general_embed.set_footer() # Clears the footer so it doesn't show the staff member in the DM
                         await member.send(embed=general_embed)
                 except Exception:
                     pass

--- a/cogs/reportsupport.py
+++ b/cogs/reportsupport.py
@@ -651,7 +651,7 @@ class ReportSupport(*report_support_classes):
         await self.report_action(interaction, "user", reportee, text, evidence)
 
     # - Get generic help
-    async def generic_help(self, interaction: discord.Interaction, type_help: str, message: str, ping: bool = True) -> None:
+    async def generic_help(self, interaction: discord.Interaction, type_help: str, desc: str, ping: bool = True) -> None:
         """ Opens a generic help channel.
         :param interaction: The interaction that generated this action.
         :param type_help: The kind of general help.
@@ -691,7 +691,8 @@ class ReportSupport(*report_support_classes):
             await interaction.followup.send(embed=created_embed, ephemeral=True)
             current_ts = await utils.get_timestamp()
             await self.insert_user_open_channel(member.id, the_channel.id, current_ts)
-            embed = discord.Embed(title=f"{type_help.title()}!", description=message, color=discord.Color.red())
+            embed = discord.Embed(title=f"{type_help.title()}!", description=f"{member.mention}", colour=member.color)
+            embed.add_field(name="Description:", value=f"```{desc}```", inline=False)
 
             if ping:
                 await the_channel.send(content=f"{member.mention}, {moderator.mention}", embed=embed)

--- a/extra/modals.py
+++ b/extra/modals.py
@@ -391,7 +391,7 @@ class UserReportSupportDetailModal(Modal):
         self.add_item(
             InputText(
                 label="Do you possess evidence of what happened?",
-                placeholder="Recording, screenshots or witnesses can be considered as evidence ",
+                placeholder="Only recordings or screenshots can be considered as evidence ",
                 style=discord.InputTextStyle.paragraph,
                 min_length=2
             )
@@ -469,7 +469,7 @@ class UserReportStaffDetailModal(Modal):
         self.add_item(
             InputText(
                 label="Do you possess evidence of what happened?",
-                placeholder="Recording, screenshots or witnesses can be considered as evidence ",
+                placeholder="Only recordings or screenshots can be considered as evidence ",
                 style=discord.InputTextStyle.paragraph,
                 min_length=2
             )

--- a/extra/modals.py
+++ b/extra/modals.py
@@ -499,6 +499,52 @@ class UserReportStaffDetailModal(Modal):
         elif self.option == 'Oopsie':
             return #await interaction.followup.send("**All right, cya!**", ephemeral=True)
 
+class UserReportHelpDetailModal(Modal):
+    """ Class for specifying details for a Role Help and General Help request. """
+
+    def __init__(self, client: commands.Bot, option: str) -> None:
+        """ Class init method. """
+
+        super().__init__(title="Help Request")
+        self.client = client
+        self.cog: commands.Cog = client.get_cog('ReportSupport')
+        self.add_item(
+            InputText(
+                label="What kind of help do you need?",
+                placeholder="Describe what you need help with in detail, so we can assist you better and faster.",
+                style=discord.InputTextStyle.paragraph
+            )
+        )
+        self.option = option
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """ Callback for the form modal. """
+
+        await interaction.response.defer()
+        help_request = self.children[0].value
+
+        if self.option == 'report_help':
+            try:
+                exists = await self.cog.generic_help(interaction, 'role help', help_request)
+                if exists is False:
+                    return
+            except Exception as e:
+                print(e)
+            else:
+                return
+
+        elif self.option == 'report_support':
+            try:
+                exists = await self.cog.generic_help(interaction, 'general help', help_request)
+                if exists is False:
+                    return
+            except Exception as e:
+                print(e)
+            else:
+                return
+
+        elif self.option == 'Oopsie':
+            return await interaction.followup.send("**All right, cya!**", ephemeral=True)
 
 class TravelBuddyModal(Modal):
     """ Class for the TravelBuddies feature. """

--- a/extra/view.py
+++ b/extra/view.py
@@ -18,7 +18,7 @@ from .modals import (BootcampFeedbackModal, DebateOrganizerApplicationModal,
                      TeacherApplicationModal)
 from .select import ReportStaffSelect, ReportSupportSelect
 
-from .modals import UserReportStaffDetailModal, UserReportSupportDetailModal
+from .modals import UserReportStaffDetailModal, UserReportSupportDetailModal, UserReportHelpDetailModal
 
 # variables.role
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
@@ -94,8 +94,8 @@ class ReportView(discord.ui.View):
             await interaction.response.send_modal(modal)
 
         elif interaction.data["values"][0] == "report_help" or interaction.data["values"][0] == "report_support":
-            modal = UserReportSupportDetailModal(self.client, interaction.data['values'][0])
-            await modal.callback(interaction)
+            modal = UserReportHelpDetailModal(self.client, interaction.data['values'][0])
+            await interaction.response.send_modal(modal)
 
         elif interaction.data["values"][0] == "verify":
             member_ts = self.cog.cache.get(member.id)


### PR DESCRIPTION
- ban requests no longer fails after 5 minutes and now can get denied by staff managers and admins
- new timeout commands for admins, for both giving and removing timeouts
- forms added to help cases, let's see if this helps with the help cases opened by mistake 
- infraction edits no longer doxes the staff member who did it
- changed placeholder messages for evidence text boxes

tested and works. hopefully nothing breaks in the main bot.