### PR TITLE
fix: staff command fixes and other fixes 

### DIFF
--- a/cogs/aspirantsactivity.py
+++ b/cogs/aspirantsactivity.py
@@ -15,7 +15,7 @@ from mysqldb import DatabaseCore
 guild_id = int(os.getenv('SERVER_ID', 123))
 
 # variables.role
-senior_mod_role_id: int = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id: int = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
 
 class AspirantActivity(AspirantsTable):
@@ -77,7 +77,7 @@ class AspirantActivity(AspirantsTable):
             await self.add_aspirant_time(member.id, addition)
 
     ### Commands
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['asprep', 'asp_rep'])
     async def aspirant_rep(self, ctx) -> None:
         """ (STAFF) Shows all the aspirants and their statuses in an embedded message. """
@@ -129,7 +129,7 @@ class AspirantActivity(AspirantsTable):
             return await resp.delete()
 
 
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['addasp', 'add_asp'])
     async def add_aspirant(self, ctx, members: commands.Greedy[discord.Member] = None) -> None:
         """Adds an aspirant from the activity monitor
@@ -150,7 +150,7 @@ class AspirantActivity(AspirantsTable):
                 return await ctx.send(f"**The user {member} is already been monitored**")
 
 
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['del_asp', 'delasp'])
     async def remove_aspirant(self, ctx, members: commands.Greedy[discord.Member] = None) -> None:
         """Removes an aspirant from the activity monitor

--- a/cogs/bootcamp.py
+++ b/cogs/bootcamp.py
@@ -21,7 +21,7 @@ guild_id = int(os.getenv('SERVER_ID', 123))
 guild_ids = [guild_id]
 
 # variables.role
-senior_mod_role_id: int = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id: int = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
 
 class Bootcamp(commands.Cog):

--- a/cogs/communication.py
+++ b/cogs/communication.py
@@ -15,7 +15,7 @@ from mysqldb import DatabaseCore
 
 # variables.role
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
-senior_mod_role_id = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 allowed_roles = [int(os.getenv('OWNER_ROLE_ID', 123)), int(os.getenv('ADMIN_ROLE_ID', 123)), mod_role_id]
 lesson_manager_role_id = int(os.getenv('LESSON_MANAGEMENT_ROLE_ID', 123))
 event_manager_role_id = int(os.getenv('EVENT_MANAGER_ROLE_ID', 123))
@@ -254,7 +254,7 @@ If you have any questions feel free to ask! And if you experience any type of pr
             
     #greedy_dm
     @commands.command()
-    @utils.is_allowed([senior_mod_role_id, lesson_manager_role_id, event_manager_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id, lesson_manager_role_id, event_manager_role_id], throw_exc=True)
     async def dm(self, ctx, *, message: Optional[str] = None):
         """ (SeniorMod | Manager) Sends a Direct Message to one or more users.
         :param members: The @ or the ID of one or more users to mute.

--- a/cogs/embeds.py
+++ b/cogs/embeds.py
@@ -16,7 +16,7 @@ guild_ids = [int(os.getenv('SERVER_ID', 123))]
 admin_role_id = int(os.getenv('ADMIN_ROLE_ID', 123))
 owner_role_id = int(os.getenv('OWNER_ROLE_ID', 123))
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
-senior_mod_role_id = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 lesson_manager_role_id = int(os.getenv('LESSON_MANAGEMENT_ROLE_ID', 123))
 allowed_roles = [owner_role_id, admin_role_id, mod_role_id]
 
@@ -80,7 +80,7 @@ class Embeds(commands.Cog):
         await ctx.send(embed=embed)
 
     @slash_command(name="embed", default_permission=False, guild_ids=guild_ids)
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     async def _embed(self, ctx,
         description: Option(str, name="description", description="Description.", required=False),
         title: Option(str, name="title", description="Title.", required=False),

--- a/cogs/eventmanagement.py
+++ b/cogs/eventmanagement.py
@@ -17,7 +17,7 @@ server_id = int(os.getenv('SERVER_ID', 123))
 
 # variables.role
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
-senior_mod_role_id = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 admin_role_id = int(os.getenv('ADMIN_ROLE_ID', 123))
 owner_role_id = int(os.getenv('OWNER_ROLE_ID', 123))
 event_host_role_id = int(os.getenv('EVENT_HOST_ROLE_ID', 123))
@@ -71,7 +71,7 @@ class EventManagement(EventRoomsTable):
             try:
                 member = guild.get_member(user_id)
                 # Mods+ shouldn't get disconnected from the Camera only channel
-                if await utils.is_allowed([mod_role_id, senior_mod_role_id]).predicate(member=member, channel=bots_and_commands_channel):
+                if await utils.is_allowed([mod_role_id, staff_manager_role_id]).predicate(member=member, channel=bots_and_commands_channel):
                     continue
 
                 if not member.voice or not (vc := member.voice.channel):

--- a/cogs/modactivity.py
+++ b/cogs/modactivity.py
@@ -17,7 +17,7 @@ from mysqldb import DatabaseCore
 guild_id = int(os.getenv('SERVER_ID', 123))
 
 # variables.role
-senior_mod_role_id: int = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id: int = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
 
 class ModActivity(ModActivityTable):
@@ -67,7 +67,7 @@ class ModActivity(ModActivityTable):
             await self.update_moderator_time(member.id, addition)
 
 
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['mods_reputation', 'mod_rep'])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def modrep(self, ctx):
@@ -213,7 +213,7 @@ class ModActivity(ModActivityTable):
         dm_embed.set_footer(text=f"Sent by: Sloth")
         await dm_log.send(embed=dm_embed)
 
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['track_mod'])
     async def track_mod_activity(self, ctx, mod: discord.Member):
         """ (STAFF) Starts tracking a moderator activity. """
@@ -229,7 +229,7 @@ class ModActivity(ModActivityTable):
         await self.insert_moderator(mod.id)
         return await ctx.send(f"**Tracking {mod.mention} activity!**")
 
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['untrack_mod'])
     async def untrack_mod_activity(self, ctx, mod: discord.Member):
         """ (STAFF) Stop tracking a moderator activity. Use this command if an user is no longer a moderator. """
@@ -246,7 +246,7 @@ class ModActivity(ModActivityTable):
         await self.remove_moderator(mod.id)
         return await ctx.send(f"**Untracking {mod.mention} activity!**")
 
-    @utils.is_allowed([senior_mod_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id], throw_exc=True)
     @commands.command(aliases=['sync_mods'])
     async def sync_mod_activity(self, ctx):
         await self.delete_mod_activity()

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -820,6 +820,8 @@ class Moderation(*moderation_cogs):
                     warn_desc = f'**Reason:** {reason}'
                     user_infractions = await self.get_user_infractions(member.id)
                     hours, days, weeks, ban = await self.get_timeout_time(ctx, member, await self.get_timeout_warns(infr, user_infractions))
+                    
+                    log_timeout = None # otherwise warn shits itself and dies
                     if ban:
                         warn_desc += '\n**User has exceeded the maximum warn limit within 6 months and will be banned!**'
                     else:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -68,6 +68,7 @@ scamwords = [
     "xcoin-presale.com",
     "ainexusca.com",
     "u.to",
+    "e.vg",
     # numbers
     "+1 (618) 913-0036",
     "+1 (626) 514-0696",

--- a/cogs/reportsupport.py
+++ b/cogs/reportsupport.py
@@ -48,7 +48,7 @@ ban_appeals_channel_id: int = os.getenv("BAN_APPEALS_CHANNEL_ID", 123)
 
 # variables.role #
 moderator_role_id = int(os.getenv('MOD_ROLE_ID', 123))
-senior_role_id = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
 admin_role_id = int(os.getenv('ADMIN_ROLE_ID', 123))
 lesson_management_role_id = int(os.getenv('LESSON_MANAGEMENT_ROLE_ID', 123))
 event_management_role_id = int(os.getenv('EVENT_MANAGER_ROLE_ID', 123))
@@ -508,7 +508,7 @@ class ReportSupport(*report_support_classes):
         }
         
         if (vc_name == "staff"):
-            senior_mod = discord.utils.get(guild.roles, id=senior_role_id)
+            senior_mod = discord.utils.get(guild.roles, id=staff_manager_role_id)
             overwrites.update({
                 moderator: discord.PermissionOverwrite(
                     read_messages=False, 
@@ -953,7 +953,7 @@ class ReportSupport(*report_support_classes):
 
     # In-game commands
     
-    @utils.is_allowed([lesson_management_role_id], throw_exc=True)
+    @utils.is_allowed([staff_manager_role_id, lesson_management_role_id, event_management_role_id], throw_exc=True)
     @commands.command(aliases=['ca'])
     async def close_app(self, ctx) -> None:
         """ (ADMIN) Closes an application channel. """

--- a/cogs/slothcurrency.py
+++ b/cogs/slothcurrency.py
@@ -35,7 +35,7 @@ guild_ids = [int(os.getenv('SERVER_ID', 123))]
 booster_role_id = int(os.getenv('BOOSTER_ROLE_ID', 123))
 teacher_role_id = int(os.getenv("TEACHER_ROLE_ID", 123))
 mod_role_id = int(os.getenv("MOD_ROLE_ID", 123))
-senior_mod_role_id = int(os.getenv("SENIOR_MOD_ROLE_ID", 123))
+staff_manager_role_id = int(os.getenv("STAFF_MANAGER_ROLE_ID", 123))
 
 currency_cogs: List[commands.Cog] = [
     UserItemsTable, UserServerActivityTable, UserCurrencyTable,
@@ -817,7 +817,7 @@ class SlothCurrency(*currency_cogs):
             await ctx.send(f"**{ctx.author.mention} transferred {money}łł to {member.mention}!**")
 
         if money == 25:
-            if await utils.is_allowed([mod_role_id, senior_mod_role_id]).predicate(channel=ctx.channel, member=member):
+            if await utils.is_allowed([mod_role_id, staff_manager_role_id]).predicate(channel=ctx.channel, member=member):
                 await SlothClass.complete_quest(author.id, 7, staff_id=member.id)
             if await utils.is_allowed([teacher_role_id]).predicate(channel=ctx.channel, member=member):
                 await SlothClass.complete_quest(author.id, 10, teacher_id=member.id)

--- a/cogs/tools.py
+++ b/cogs/tools.py
@@ -39,7 +39,7 @@ dnk_id = int(os.getenv('DNK_ID', 123))
 
 # variables.role
 mod_role_id = int(os.getenv('MOD_ROLE_ID', 123))
-senior_mod_role_id: int = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id: int = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 admin_role_id = int(os.getenv('ADMIN_ROLE_ID', 123))
 owner_role_id = int(os.getenv('OWNER_ROLE_ID', 123))
 analyst_debugger_role_id: int = int(os.getenv('ANALYST_DEBUGGER_ROLE_ID', 123))
@@ -233,7 +233,7 @@ class Tools(*tool_cogs):
 
 	# Countsdown from a given number
 	@commands.command()
-	@utils.is_allowed([senior_mod_role_id], throw_exc=True)
+	@utils.is_allowed([staff_manager_role_id], throw_exc=True)
 	async def count(self, ctx, amount=0):
 		""" (ADM) Countsdown by a given number
 		:param amount: The start point. """
@@ -654,7 +654,7 @@ class Tools(*tool_cogs):
 		await ctx.send(' '.join(text))
 
 	@commands.command(aliases=['tp', 'beam'])
-	@commands.check_any(utils.is_allowed([senior_mod_role_id]))
+	@commands.check_any(utils.is_allowed([staff_manager_role_id]))
 	async def teleport(self, ctx, vc_1: discord.VoiceChannel = None, vc_2: discord.VoiceChannel = None) -> None:
 		""" Teleports all members in a given voice channel to another one.
 		:param vc_1: The origin vc.
@@ -1164,7 +1164,7 @@ class Tools(*tool_cogs):
 			await ctx.respond(f"**They were brought to {user_vc.channel.mention}!**")
 
 	@commands.command()
-	@utils.is_allowed([senior_mod_role_id], throw_exc=True)
+	@utils.is_allowed([staff_manager_role_id], throw_exc=True)
 	async def stealth(self, ctx, member: Optional[discord.Member] = None) -> None:
 		""" Makes you stealth, so when you join a VC you don't get the 'in a VC' role.
 		:param member: The member to make stealth. [Optional][Default = You] """
@@ -1244,7 +1244,7 @@ class Tools(*tool_cogs):
 			await ctx.respond(f"**You got moved to {channel.mention}!**")
 
 	@commands.command()
-	@utils.is_allowed([senior_mod_role_id, admin_role_id, owner_role_id], throw_exc=True)
+	@utils.is_allowed([staff_manager_role_id, admin_role_id, owner_role_id], throw_exc=True)
 	async def surf(self, ctx, member: Optional[discord.Member] = None) -> None:
 		""" Makes a member surf in the empty Dynamic Rooms, to delete them.
 		:param member: The member who's gonna surf. [Optional][Default = You] """

--- a/cogs/voicemanagement.py
+++ b/cogs/voicemanagement.py
@@ -14,7 +14,7 @@ server_id = int(os.getenv('SERVER_ID', 123))
 
 # variables.role
 mod_role_id: int = int(os.getenv("MOD_ROLE_ID", 123))
-senior_mod_role_id: int = int(os.getenv("SENIOR_MOD_ROLE_ID", 123))
+staff_manager_role_id: int = int(os.getenv("STAFF_MANAGER_ROLE_ID", 123))
 
 # variables.textchannel
 bots_and_commands_channel_id = int(os.getenv('BOTS_AND_COMMANDS_CHANNEL_ID', 123))
@@ -68,7 +68,7 @@ class VoiceManagement(commands.Cog):
                     try:
                         member = guild.get_member(user_id)
                         # Mods+ shouldn't get disconnected from the Camera only channel
-                        if await utils.is_allowed([mod_role_id, senior_mod_role_id]).predicate(member=member, channel=bots_and_commands_channel):
+                        if await utils.is_allowed([mod_role_id, staff_manager_role_id]).predicate(member=member, channel=bots_and_commands_channel):
                             continue
 
                         if not member.voice or not (vc := member.voice.channel):

--- a/extra/minigames/whitejack/whitejack.py
+++ b/extra/minigames/whitejack/whitejack.py
@@ -23,7 +23,7 @@ server_id: int = int(os.getenv('SERVER_ID', 123))
 
 # variables.role
 allowed_roles = [
-    int(os.getenv('OWNER_ROLE_ID', 123)), int(os.getenv('ADMIN_ROLE_ID', 123)), int(os.getenv('SENIOR_MOD_ROLE_ID', 123)),
+    int(os.getenv('OWNER_ROLE_ID', 123)), int(os.getenv('ADMIN_ROLE_ID', 123)), int(os.getenv('STAFF_MANAGER_ROLE_ID', 123)),
     int(os.getenv('MOD_ROLE_ID', 123)), int(os.getenv('ANALYST_DEBUGGER_ROLE_ID', 123)), *patreon_roles.keys()
 ]
 

--- a/extra/reportsupport/applications.py
+++ b/extra/reportsupport/applications.py
@@ -12,7 +12,7 @@ from extra import utils
 # variables.role
 owner_role_id: int = int(os.getenv('OWNER_ROLE_ID', 123))
 moderator_role_id: int = int(os.getenv('MOD_ROLE_ID', 123))
-senior_mod_role_id: int = int(os.getenv('SENIOR_MOD_ROLE_ID', 123))
+staff_manager_role_id: int = int(os.getenv('STAFF_MANAGER_ROLE_ID', 123))
 admin_role_id: int = int(os.getenv('ADMIN_ROLE_ID', 123))
 lesson_management_role_id: int = int(os.getenv('LESSON_MANAGEMENT_ROLE_ID', 123))
 event_manager_role_id: int = int(os.getenv('EVENT_MANAGER_ROLE_ID', 123))
@@ -48,7 +48,7 @@ class ApplicationsTable(commands.Cog):
         'moderator': {
             "app": moderator_app_channel_id, "interview": moderator_interview_vc_id, "parent": moderator_parent_channel_id,
             "message": "**Moderator Application**\nOur staff has evaluated your Moderator application and has come to a conclusion, and due to internal and unspecified reasons we are **declining** it. Thank you anyways",
-            "pings": [{"id": owner_role_id, "role": True}, {"id": admin_role_id, "role": True}, {"id": senior_mod_role_id, "role": True}]},
+            "pings": [{"id": owner_role_id, "role": True}, {"id": admin_role_id, "role": True}, {"id": staff_manager_role_id, "role": True}]},
         'event_host': {
             "app": event_host_app_channel_id,  "interview": event_host_interview_vc_id, "parent": event_host_parent_channel_id, 
             "message": "**Event Host Application**\nOur staff has evaluated your Event Host application and has come to the conclusion that we are not in need of this event.",
@@ -89,10 +89,10 @@ class ApplicationsTable(commands.Cog):
                 if await utils.is_allowed([lesson_management_role_id]).predicate(channel=channel, member=payload.member):
                     return await self.handle_application(guild, payload)
             elif payload.channel_id == self.moderator_app_channel_id: # User is a Staff Manager+
-                if await utils.is_allowed([senior_mod_role_id]).predicate(channel=channel, member=payload.member):
+                if await utils.is_allowed([staff_manager_role_id]).predicate(channel=channel, member=payload.member):
                     return await self.handle_application(guild, payload)
             elif payload.channel_id == self.ban_appeals_channel_id: # User is a Staff Manager+
-                if await utils.is_allowed([senior_mod_role_id]).predicate(channel=channel, member=payload.member):
+                if await utils.is_allowed([staff_manager_role_id]).predicate(channel=channel, member=payload.member):
                     return await self.handle_ban_appeal(guild, payload)
             elif adm: # User is an adm
                 return await self.handle_application(guild, payload)


### PR DESCRIPTION
- mod couldn't warn each other for some reason, it's fixed (or maybe not, we'll see)
- close application command was only usable by lesson managers, now it's usable by staff and event managers as well
- new scam link added to the list
- internal staff manager role variable name is changed

mostly tested and works.