### PR TITLE
fix(apply): cache got deleted by mistake

### DIFF
--- a/cogs/reportsupport.py
+++ b/cogs/reportsupport.py
@@ -59,6 +59,7 @@ class ReportSupport(*report_support_classes):
         self.db = DatabaseCore()
         self.owner_role_id: int = int(os.getenv('OWNER_ROLE_ID', 123))
         self.mayu_id: int = int(os.getenv('MAYU_ID', 123))
+        self.cache = {}
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:


### PR DESCRIPTION
cleaning that ai slop is probably going to be the worst cleanup experience for quite some time

- cache used by apply forms that got deleted by mistake is added back

tested and works.